### PR TITLE
watch changes to default value

### DIFF
--- a/src/Prompt.js
+++ b/src/Prompt.js
@@ -60,8 +60,8 @@ export default class Prompt extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { visible } = nextProps;
-    this.setState({ visible });
+    const { visible, defaultValue } = nextProps;
+    this.setState({ visible, value:defaultValue });
   }
 
   _onChangeText = (value) => {


### PR DESCRIPTION
I had a little issue when using a dynamic defaultValue since **state.value** is set to **props.defaultValue** in **componentDidMount()**.  If the default value changes even before the prompt is visible, **state.value** will still be set to the old default value and if the user submits without typing anything, that old value will be submitted even though the text shown is the new default value.

For example, my dynamic default value looks like this: 
            `defaultValue={ this.state.user ? this.state.user.name : '' }`
which will not update properly in **Prompt.state.value** when the user is set in my component's state after mounting.
