### PR TITLE
Remove unnecessary flex:1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-prompt",
-  "version": "0.18.6",
+  "version": "0.18.7",
   "description": "A cross-platform prompt component for React Native.",
   "repository": {
     "type": "git",

--- a/src/styles.js
+++ b/src/styles.js
@@ -32,18 +32,15 @@ export default StyleSheet.create({
     fontWeight: '600'
   },
   dialogBody: {
-    flex: 1,
     paddingHorizontal: 10
   },
   dialogInput: {
-    flex: 1,
     height: 50,
     fontSize: 18
   },
   dialogFooter: {
     borderTopWidth: 1,
     flexDirection: 'row',
-    flex: 1
   },
   dialogAction: {
     flex: 1,


### PR DESCRIPTION
This fixes an issue caused by a breaking change in React Native 0.36:  https://github.com/facebook/react-native/commit/0a9b6bedb312eba22c5bc11498b1cc41363e5f27 that caused these elements to be collapsed to height: 0
