### PR TITLE
Fixes error undefined is not an object (evaluating '_react2.PropTypes.string')

### DIFF
--- a/src/Prompt.js
+++ b/src/Prompt.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
   Modal,
   Platform,


### PR DESCRIPTION
Fixes error `undefined is not an object (evaluating '_react2.PropTypes.string')`.
React Native Version: 0.51.0