### PR TITLE
Add new include for PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-prompt",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A cross-platform prompt component for React Native.",
   "repository": {
     "type": "git",

--- a/src/Prompt.js
+++ b/src/Prompt.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
   Modal,
   Platform,

--- a/src/Prompt.js
+++ b/src/Prompt.js
@@ -63,7 +63,9 @@ export default class Prompt extends Component {
 
   componentWillReceiveProps(nextProps) {
     const { visible, defaultValue } = nextProps;
-    this.setState({ visible, value:defaultValue });
+    if(visible !== this.props.visible && visible) {
+      this.setState({ visible, value: defaultValue });
+    }
   }
 
   _onChangeText = (value) => {
@@ -115,6 +117,7 @@ export default class Prompt extends Component {
             <TextInput
               style={[styles.dialogInput, inputStyle]}
               defaultValue={defaultValue}
+              value={this.state.value}
               onChangeText={this._onChangeText}
               placeholder={placeholder}
               autoFocus={true}

--- a/src/Prompt.js
+++ b/src/Prompt.js
@@ -61,11 +61,18 @@ export default class Prompt extends Component {
     this.setState({value: this.props.defaultValue});
   }
 
-  componentWillReceiveProps(nextProps) {
+  /*componentWillReceiveProps(nextProps) {
     const { visible, defaultValue } = nextProps;
     if(visible !== this.props.visible && visible) {
       this.setState({ visible, value: defaultValue });
     }
+  }*/
+  static getDerivedStateFromProps(nextProps, prevState) {
+    const { visible, defaultValue } = nextProps;
+    if(visible !== nextProps.visible && visible) {
+      return { visible: defaultValue };
+    }
+    return null;
   }
 
   _onChangeText = (value) => {


### PR DESCRIPTION
As of React Native 15.5, PropTypes is no longer found under "react" but rather under "prop-types". (https://reactjs.org/blog/2017/04/07/react-v15.5.0.html)