### PR TITLE
Proptypes to use latest React + proptypes package

### DIFF
--- a/src/Prompt.js
+++ b/src/Prompt.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
   Modal,
   Platform,


### PR DESCRIPTION
Since latest React is using a separate package for `prop-types` this change was needed