### PR TITLE
PropTypes fixed to package 'prop-types'

### DIFF
--- a/src/Prompt.js
+++ b/src/Prompt.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import {
   Modal,
   Platform,
@@ -7,6 +7,7 @@ import {
   TouchableWithoutFeedback,
   View
 } from 'react-native';
+import PropTypes from 'prop-types';
 import styles from './styles';
 
 export default class Prompt extends Component {


### PR DESCRIPTION
Compatible with React 15.3+ and RN 0.49+